### PR TITLE
return result type instead of panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,6 @@ repository = "https://github.com/XAnything/xntp"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.69"
 byteorder = "1.4.3"
 chrono = "0.4.23"


### PR DESCRIPTION
Instead of just unwrapping, we now return a Result that contains the error that occurred. 
This is helpful when using the xntp library and no internet connection is available or the ntp server address was wrong. Before the change the code would panic, now it returns an error.